### PR TITLE
apr: fix off_t size can't match when configure and in target glibc when cross compiling

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1786,7 +1786,7 @@ fi
 
 size_t_fmt="#define APR_SIZE_T_FMT \"$size_t_fmt\""
 
-APR_CHECK_SIZEOF_EXTENDED([#include <sys/types.h>], off_t, 8)
+AC_CHECK_SIZEOF(off_t)
 
 if test "${ac_cv_sizeof_off_t}${apr_cv_use_lfs64}" = "4yes"; then
     # Enable LFS


### PR DESCRIPTION
In configure.in, it contains the following:

	APR_CHECK_SIZEOF_EXTENDED([#include <sys/types.h>], off_t, 8)

the macro "APR_CHECK_SIZEOF_EXTENDED" was defined in build/apr_common.m4,
it use the "AC_TRY_RUN" macro, this macro let the off_t to 8, when cross
compiling enable.

So it was hardcoded for cross compiling, we should detect it dynamic based on
the sysroot's glibc. We change it to the following:

	AC_CHECK_SIZEOF(off_t)

Signed-off-by: DengkeDu <pinganddu90@gmail.com>