### PR TITLE
fix windows builds for _WIN32_WINNT>=0x0600, broken by commit 30cab59

### DIFF
--- a/network_io/unix/sockaddr.c
+++ b/network_io/unix/sockaddr.c
@@ -29,6 +29,11 @@
 #include <net/if.h>
 #endif
 
+#if defined(HAVE_IF_INDEXTONAME) && defined(_MSC_VER)
+#include <Iphlpapi.h>
+#pragma comment(lib, "Iphlpapi.lib")
+#endif
+
 #define APR_WANT_STRFUNC
 #include "apr_want.h"
 


### PR DESCRIPTION
https://github.com/apache/apr/commit/30cab5973bc9486e7c59db524fd5292f8f96a258#diff-da362550a92a27777b3f4d4527632435R140

In particular, IF_NAMESIZE was not defined

Feel free to change this to however the project normally handles these things.