### PR TITLE
BZ-56090: installbuilddir as defined with --enable-layout is not used

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -70,6 +70,7 @@ exec_prefix=@exec_prefix@
 bindir=@bindir@
 libdir=@libdir@
 includedir=@includedir@
+datadir=@datadir@
 installbuilddir=@installbuilddir@
 
 LDADD_dbd_pgsql = @LDADD_dbd_pgsql@

--- a/config.layout
+++ b/config.layout
@@ -223,6 +223,7 @@
     libexecdir:    ${exec_prefix}/lib/apr/modules
     mandir:        ${exec_prefix}/share/man
     datadir:       ${exec_prefix}/share/apr
+    installbuilddir: ${datadir}/build-${APR_MAJOR_VERSION}
     includedir:    ${exec_prefix}/include/apr-${APR_MAJOR_VERSION}
     localstatedir: ${prefix}/var/run
     runtimedir:    ${prefix}/var/run

--- a/configure.in
+++ b/configure.in
@@ -286,8 +286,8 @@ AC_PROG_LIBTOOL
     ;;
 esac
 
-AC_ARG_WITH(installbuilddir, [  --with-installbuilddir=DIR location to store APR build files (defaults to '${datadir}/build')],
-  [ installbuilddir=$withval ], [ installbuilddir="${datadir}/build-${APR_MAJOR_VERSION}" ] )
+AC_ARG_WITH(installbuilddir, [  --with-installbuilddir=DIR location to store APR build files],
+  [ installbuilddir=$withval ] )
 AC_SUBST(installbuilddir)
 
 AC_ARG_WITH(libtool, [  --without-libtool       avoid using libtool to link the library],


### PR DESCRIPTION
If `--with-installbuilddir` is not supplied, it unconditially overrides the value
set by `APR_SET_LAYOUT`. Disable that and stop showing an invalid default value.