### PR TITLE
BZ-62640: libbtool invocations should use --tag=CC

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -34,7 +34,7 @@ INSTALL_DATA = @INSTALL_DATA@
 
 EXTRA_OBJECTS = @EXTRA_OBJECTS@
 APR_DSO_MODULES = @APR_DSO_MODULES@
-LINK_MODULE = $(LIBTOOL) $(LTFLAGS) --mode=link $(CC) $(LT_LDFLAGS) $(ALL_CFLAGS) $(ALL_LDFLAGS) $(APRUTIL_LDFLAGS) -release $(APR_MAJOR_VERSION) -module -rpath $(APR_DSO_LIBDIR)
+LINK_MODULE = $(LIBTOOL) $(LTFLAGS) --mode=link --tag=CC $(CC) $(LT_LDFLAGS) $(ALL_CFLAGS) $(ALL_LDFLAGS) $(APRUTIL_LDFLAGS) -release $(APR_MAJOR_VERSION) -module -rpath $(APR_DSO_LIBDIR)
 APR_DSO_LIBDIR = @APR_DSO_LIBDIR@
 APRUTIL_EXPORT_LIBS = @APRUTIL_EXPORT_LIBS@
 
@@ -173,7 +173,7 @@ include/private/apr_escape_test_char.h: tools/gen_test_char@EXEEXT@
 	$(APR_MKDIR) include/private
 	tools/gen_test_char@EXEEXT@ > $@
 
-LINK_PROG = $(LIBTOOL) $(LTFLAGS) --mode=link $(COMPILE) $(LT_LDFLAGS) \
+LINK_PROG = $(LIBTOOL) $(LTFLAGS) --mode=link --tag=CC $(COMPILE) $(LT_LDFLAGS) \
 	    @LT_NO_INSTALL@ $(ALL_LDFLAGS) -o $@
 
 # DO NOT REMOVE

--- a/configure.in
+++ b/configure.in
@@ -294,9 +294,9 @@ AC_ARG_WITH(libtool, [  --without-libtool       avoid using libtool to link the 
   [ use_libtool=$withval ], [ use_libtool="yes" ] )
 
 if test "x$use_libtool" = "xyes"; then
-      lt_compile='$(LIBTOOL) $(LTFLAGS) --mode=compile $(COMPILE) -o $@ -c $< && touch $@'
+      lt_compile='$(LIBTOOL) $(LTFLAGS) --mode=compile --tag=CC $(COMPILE) -o $@ -c $< && touch $@'
       LT_VERSION="-version-info `$get_version libtool $version_hdr APR`"
-      link="\$(LIBTOOL) \$(LTFLAGS) --mode=link \$(COMPILE) \$(LT_LDFLAGS) \$(LT_VERSION) \$(ALL_LDFLAGS) -o \$@"
+      link="\$(LIBTOOL) \$(LTFLAGS) --mode=link --tag=CC \$(COMPILE) \$(LT_LDFLAGS) \$(LT_VERSION) \$(ALL_LDFLAGS) -o \$@"
       so_ext='lo'
       lib_target='-rpath $(libdir) $(OBJECTS)'
       export_lib_target='-rpath \$(libdir) \$(OBJECTS)'

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -75,7 +75,7 @@ INCLUDES=-I$(INCDIR) -I$(srcdir)/../include
 
 # link programs using -no-install to get real executables not
 # libtool wrapper scripts which link an executable when first run.
-LINK_PROG = $(LIBTOOL) $(LTFLAGS) --mode=link $(COMPILE) $(LT_LDFLAGS) \
+LINK_PROG = $(LIBTOOL) $(LTFLAGS) --mode=link --tag=CC $(COMPILE) $(LT_LDFLAGS) \
 	    @LT_NO_INSTALL@ $(ALL_LDFLAGS) -o $@
 
 # STDTEST_PORTABLE;
@@ -123,18 +123,18 @@ globalmutexchild@EXEEXT@: $(OBJECTS_globalmutexchild)
 
 # Note -prefer-pic is only supported with libtool-1.4+
 mod_test.lo: $(srcdir)/mod_test.c
-	$(LIBTOOL) $(LTFLAGS) --mode=compile $(COMPILE) -prefer-pic -o $@ \
+	$(LIBTOOL) $(LTFLAGS) --mode=compile --tag=CC $(COMPILE) -prefer-pic -o $@ \
 	  -c $(srcdir)/mod_test.c
 
 OBJECTS_mod_test = mod_test.lo
 mod_test.la: $(OBJECTS_mod_test) $(LOCAL_LIBS)
-	$(LIBTOOL) $(LTFLAGS) --mode=link $(COMPILE) -rpath `pwd` -module \
+	$(LIBTOOL) $(LTFLAGS) --mode=link --tag=CC $(COMPILE) -rpath `pwd` -module \
 	  -avoid-version $(LT_LDFLAGS) $(ALL_LDFLAGS) -o $@ \
 	  $(OBJECTS_mod_test) $(LOCAL_LIBS)
 
 OBJECTS_libmod_test = mod_test.lo $(LOCAL_LIBS)
 libmod_test.la: $(OBJECTS_libmod_test)
-	$(LIBTOOL) $(LTFLAGS) --mode=link $(COMPILE) -rpath `pwd` \
+	$(LIBTOOL) $(LTFLAGS) --mode=link --tag=CC $(COMPILE) -rpath `pwd` \
 	  -avoid-version $(LT_LDFLAGS) $(ALL_LDFLAGS) -o $@ \
 	  $(OBJECTS_libmod_test) $(ALL_LIBS)
 


### PR DESCRIPTION
When using the generated/provided libtool on a different platform/compiler
libtool complains about the missing tag because a proper configuration for the
current one isn't present and cannot be derived.

Always pass '--tag=CC' for maximum portability. E.g., apr-util and tcnative
require this.