### PR TITLE
build/apr_common.m4: avoid explicit inclusion of '"confdefs.h"'

### DIFF
--- a/build/apr_common.m4
+++ b/build/apr_common.m4
@@ -467,13 +467,9 @@ AC_DEFUN([APR_TRY_COMPILE_NO_WARNING],
    CFLAGS="$CFLAGS -Werror"
  fi
  AC_COMPILE_IFELSE(
-  [AC_LANG_SOURCE(
-   [#include "confdefs.h"
-   ]
-   [[$1]]
-   [int main(int argc, const char *const *argv) {]
+  [AC_LANG_PROGRAM(
+   [[$1]],
    [[$2]]
-   [   return 0; }]
   )], [CFLAGS=$apr_save_CFLAGS
 $3],  [CFLAGS=$apr_save_CFLAGS
 $4])


### PR DESCRIPTION
The failure is observed on `autoconf-2.69d` (soon to be released
as `autoconf-2.70`). There `int64_t` detection fails as:

```
$ autoreconf && ./configure
...
checking whether int64_t and int use fmt %d... no
checking whether int64_t and long use fmt %ld... no
checking whether int64_t and long long use fmt %lld... no
configure: error: could not determine the string function for int64_t
```

This happens because `./configure` always stumbles on warning:

```
configure:3350: gcc -c -g -O2 -Werror  conftest.c >&5
In file included from conftest.c:31:
confdefs.h:22: error: "__STDC_WANT_IEC_60559_ATTRIBS_EXT__" redefined [-Werror]
   22 | #define __STDC_WANT_IEC_60559_ATTRIBS_EXT__ 1
      |
```

It's triggered by double inclusion of `"confdefs.h"` contents:
explicitly in `APR_TRY_COMPILE_NO_WARNING` macro and implicitly
via `AC_LANG_SOURCE` use.

To fix it and avoid having to define `main()` declaration the change
uses `AC_LANG_PROGRAM` instead.

Tested on both `autoconf-2.69` and `autoconf-2.69d`.

Bug: https://bugs.gentoo.org/738156
Bug: https://bugs.gentoo.org/750353