### PR TITLE
Polling wakeup: recover from possible faults or return error

### DIFF
--- a/include/arch/unix/apr_arch_poll_private.h
+++ b/include/arch/unix/apr_arch_poll_private.h
@@ -182,6 +182,8 @@ struct apr_pollcb_provider_t {
 apr_status_t apr_poll_create_wakeup_pipe(apr_pool_t *pool, apr_pollfd_t *pfd, 
                                          apr_file_t **wakeup_pipe);
 apr_status_t apr_poll_close_wakeup_pipe(apr_file_t **wakeup_pipe);
-void apr_poll_drain_wakeup_pipe(apr_file_t **wakeup_pipe);
+apr_status_t apr_poll_drain_wakeup_pipe(apr_file_t **wakeup_pipe);
+apr_status_t apr_pollset_wakeup_pipe_regenerate(apr_pollset_t *pollset);
+apr_status_t apr_pollcb_wakeup_pipe_regenerate(apr_pollcb_t *pollcb);
 
 #endif /* APR_ARCH_POLL_PRIVATE_H */

--- a/poll/unix/kqueue.c
+++ b/poll/unix/kqueue.c
@@ -257,6 +257,7 @@ static apr_status_t impl_pollset_poll(apr_pollset_t *pollset,
     int ret;
     struct timespec tv, *tvptr;
     apr_status_t rv = APR_SUCCESS;
+    apr_status_t wakeup_rv = APR_SUCCESS;
 
     *num = 0;
 
@@ -286,8 +287,15 @@ static apr_status_t impl_pollset_poll(apr_pollset_t *pollset,
             if ((pollset->flags & APR_POLLSET_WAKEABLE) &&
                 fd->desc_type == APR_POLL_FILE &&
                 fd->desc.f == pollset->wakeup_pipe[0]) {
-                apr_poll_drain_wakeup_pipe(pollset->wakeup_pipe);
                 rv = APR_EINTR;
+                if ( apr_poll_drain_wakeup_pipe(pollset->wakeup_pipe) != APR_SUCCESS )
+                {
+                    wakeup_rv = apr_pollset_wakeup_pipe_regenerate(pollset);
+                    if ( wakeup_rv != APR_SUCCESS )
+                    {
+                        rv = wakeup_rv;
+                    }
+                }
             }
             else {
                 pollset->p->result_set[j] = *fd;
@@ -473,7 +481,14 @@ static apr_status_t impl_pollcb_poll(apr_pollcb_t *pollcb,
             if ((pollcb->flags & APR_POLLSET_WAKEABLE) &&
                 pollfd->desc_type == APR_POLL_FILE &&
                 pollfd->desc.f == pollcb->wakeup_pipe[0]) {
-                apr_poll_drain_wakeup_pipe(pollcb->wakeup_pipe);
+                if ( apr_poll_drain_wakeup_pipe(pollcb->wakeup_pipe) != APR_SUCCESS )
+                {
+                    rv = apr_pollcb_wakeup_pipe_regenerate(pollcb);
+                    if ( rv != APR_SUCCESS )
+                    {
+                        return rv;
+                    }
+                }
                 return APR_EINTR;
             }
 

--- a/poll/unix/poll.c
+++ b/poll/unix/poll.c
@@ -236,6 +236,7 @@ static apr_status_t impl_pollset_poll(apr_pollset_t *pollset,
 {
     int ret;
     apr_status_t rv = APR_SUCCESS;
+    apr_status_t wakeup_rv = APR_SUCCESS;
 
     *num = 0;
 
@@ -275,8 +276,16 @@ static apr_status_t impl_pollset_poll(apr_pollset_t *pollset,
                 if ((pollset->flags & APR_POLLSET_WAKEABLE) &&
                     pollset->p->query_set[i].desc_type == APR_POLL_FILE &&
                     pollset->p->query_set[i].desc.f == pollset->wakeup_pipe[0]) {
-                    apr_poll_drain_wakeup_pipe(pollset->wakeup_pipe);
                     rv = APR_EINTR;
+
+                    if ( apr_poll_drain_wakeup_pipe(pollset->wakeup_pipe) != APR_SUCCESS )
+                    {
+                        wakeup_rv = apr_pollset_wakeup_pipe_regenerate(pollset);
+                        if ( wakeup_rv != APR_SUCCESS )
+                        {
+                            rv = wakeup_rv;
+                        }
+                    }
                 }
                 else {
                     pollset->p->result_set[j] = pollset->p->query_set[i];
@@ -422,7 +431,15 @@ static apr_status_t impl_pollcb_poll(apr_pollcb_t *pollcb,
                 if ((pollcb->flags & APR_POLLSET_WAKEABLE) &&
                     pollfd->desc_type == APR_POLL_FILE &&
                     pollfd->desc.f == pollcb->wakeup_pipe[0]) {
-                    apr_poll_drain_wakeup_pipe(pollcb->wakeup_pipe);
+
+                    if ( apr_poll_drain_wakeup_pipe(pollcb->wakeup_pipe) != APR_SUCCESS )
+                    {
+                        rv = apr_pollcb_wakeup_pipe_regenerate(pollcb);
+                        if ( rv != APR_SUCCESS )
+                        {
+                            return rv;
+                        }
+                    }
                     return APR_EINTR;
                 }
 

--- a/poll/unix/port.c
+++ b/poll/unix/port.c
@@ -359,6 +359,7 @@ static apr_status_t impl_pollset_poll(apr_pollset_t *pollset,
     apr_int32_t j;
     pfd_elem_t *ep;
     apr_status_t rv = APR_SUCCESS;
+    apr_status_t wakeup_rv = APR_SUCCESS;
 
     *num = 0;
     nget = 1;
@@ -411,8 +412,15 @@ static apr_status_t impl_pollset_poll(apr_pollset_t *pollset,
         if ((pollset->flags & APR_POLLSET_WAKEABLE) &&
             ep->pfd.desc_type == APR_POLL_FILE &&
             ep->pfd.desc.f == pollset->wakeup_pipe[0]) {
-            apr_poll_drain_wakeup_pipe(pollset->wakeup_pipe);
             rv = APR_EINTR;
+            if ( apr_poll_drain_wakeup_pipe(pollset->wakeup_pipe) != APR_SUCCESS )
+            {
+                wakeup_rv = apr_pollset_wakeup_pipe_regenerate(pollset);
+                if ( wakeup_rv != APR_SUCCESS )
+                {
+                    rv = wakeup_rv;
+                }
+            }
         }
         else {
             pollset->p->result_set[j] = ep->pfd;
@@ -563,7 +571,14 @@ static apr_status_t impl_pollcb_poll(apr_pollcb_t *pollcb,
             if ((pollcb->flags & APR_POLLSET_WAKEABLE) &&
                 pollfd->desc_type == APR_POLL_FILE &&
                 pollfd->desc.f == pollcb->wakeup_pipe[0]) {
-                apr_poll_drain_wakeup_pipe(pollcb->wakeup_pipe);
+                if ( apr_poll_drain_wakeup_pipe(pollcb->wakeup_pipe) != APR_SUCCESS )
+                {
+                    rv = apr_pollcb_wakeup_pipe_regenerate(pollcb);
+                    if ( rv != APR_SUCCESS )
+                    {
+                        return rv;
+                    }
+                }
                 return APR_EINTR;
             }
 

--- a/poll/unix/select.c
+++ b/poll/unix/select.c
@@ -346,6 +346,7 @@ static apr_status_t impl_pollset_poll(apr_pollset_t *pollset,
     struct timeval tv, *tvptr;
     fd_set readset, writeset, exceptset;
     apr_status_t rv = APR_SUCCESS;
+    apr_status_t wakeup_rv = APR_SUCCESS;
 
     *num = 0;
 
@@ -401,8 +402,17 @@ static apr_status_t impl_pollset_poll(apr_pollset_t *pollset,
         else {
             if ((pollset->flags & APR_POLLSET_WAKEABLE) &&
                 pollset->p->query_set[i].desc.f == pollset->wakeup_pipe[0]) {
-                apr_poll_drain_wakeup_pipe(pollset->wakeup_pipe);
                 rv = APR_EINTR;
+
+                if ( apr_poll_drain_wakeup_pipe(pollset->wakeup_pipe) != APR_SUCCESS )
+                {
+                    wakeup_rv = apr_pollset_wakeup_pipe_regenerate(pollset);
+                    if ( wakeup_rv != APR_SUCCESS )
+                    {
+                        rv = wakeup_rv;
+                    }
+                }
+
                 continue;
             }
             else {


### PR DESCRIPTION
Good time of day. \
We've noticed that there is a bug when wakeup pipe in polling becomes broken that leads to an instant taint of polling process \
It is possible because in Windows pipe is done via real network sockets that could be closed by network change or in some other cases \
In general, no matter the OS if wakeup pipe gets broken `apr_poll_drain_wakeup_pipe`'s status is disregarded and no action is taken
This PR is mirroring mailing list [message](https://lists.apache.org/thread.html/rdd37afa5b24fda75cff3f04738a626d30b6c98b10c969a39129bacd9%40%3Cdev.apr.apache.org%3E)