### PR TITLE
Patch apr_sleep() to use use nanosleep() on systems that support it.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1327,6 +1327,10 @@ dnl Checks for library functions. (N.B. poll is further down)
 
 AC_FUNC_ALLOCA
 
+nanosleep=0
+AC_CHECK_LIB(rt, nanosleep)
+AC_CHECK_FUNCS(nanosleep, [nanosleep="1" ])
+
 AC_CHECK_FUNCS([calloc setsid isinf isnan \
                 getenv putenv setenv unsetenv \
                 writev getifaddrs utime utimes])

--- a/time/unix/time.c
+++ b/time/unix/time.c
@@ -242,7 +242,13 @@ APR_DECLARE(void) apr_sleep(apr_interval_time_t t)
     snooze(t);
 #elif defined(NETWARE)
     delay(t/1000);
-#else
+#elif defined(HAVE_NANOSLEEP)
+    struct timespec ts;
+    int ret;
+    ts.tv_nsec = (t % APR_USEC_PER_SEC) * 1000000;
+    ts.tv_sec = t / APR_USEC_PER_SEC;
+    nanosleep(&ts, NULL);
+#else 
     struct timeval tv;
     tv.tv_usec = t % APR_USEC_PER_SEC;
     tv.tv_sec = t / APR_USEC_PER_SEC;


### PR DESCRIPTION
I tested this out on Linux (CentOS7, RHEL) as well as FreeBSD.

