### PR TITLE
Use MAP_POPULATE if available  

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1184,6 +1184,7 @@ AC_CHECK_FUNCS([mmap munmap shm_open shm_unlink shmget shmat shmdt shmctl \
                 create_area mprotect])
 
 APR_CHECK_DEFINE(MAP_ANON, sys/mman.h)
+APR_CHECK_DEFINE(MAP_POPULATE, sys/mman.h)
 AC_CHECK_FILE(/dev/zero)
 
 # Not all systems can mmap /dev/zero (such as HP-UX).  Check for that.

--- a/mmap/unix/mmap.c
+++ b/mmap/unix/mmap.c
@@ -179,9 +179,15 @@ APR_DECLARE(apr_status_t) apr_mmap_create(apr_mmap_t **new,
     set_poffset(*new, poffset);
 #endif
 
+#ifdef HAVE_MAP_POPULATE
+    mm = mmap(NULL, size + poffset,
+              native_flags, MAP_SHARED | MAP_POPULATE,
+              file->filedes, offset - poffset);
+#else
     mm = mmap(NULL, size + poffset,
               native_flags, MAP_SHARED,
               file->filedes, offset - poffset);
+#endif
 
     if (mm == (void *)-1) {
         /* we failed to get an mmap'd file... */


### PR DESCRIPTION
mmap's MAP_POPULATE will help to avoid expensive page faults by filling the page table with entries (read ahead on a file) MAP_POPULATE has been present on Linux since kernel 2.5.46 (20 years ago). 

XXX: Would it be better to scope configure.in to check to see if MAP_POPULATE returns EINVAL? 

