### PR TITLE
Fix a rare segfault in apr_global_mutex_child_init() 

### DIFF
--- a/locks/unix/global_mutex.c
+++ b/locks/unix/global_mutex.c
@@ -86,6 +86,10 @@ APR_DECLARE(apr_status_t) apr_global_mutex_child_init(
 {
     apr_status_t rv;
 
+    if (*mutex == NULL) {
+        return APR_ENOLOCK;
+    }
+
     rv = apr_proc_mutex_child_init(&((*mutex)->proc_mutex), fname, pool);
     return rv;
 }


### PR DESCRIPTION
Under specific circumstances, apr_global_mutex_child_init can be called with NULL mutex. We've seen this behavior under certain modules, specifically mod_lsapi and a few others under high load/IO wait during graceful restarts:

```
  #0  apr_proc_mutex_child_init (mutex=0x8, fname=0x0, pool=0x5566e972f128) at locks/unix/proc_mutex.c:1570
  #1  0x00002b9a5730cd2c in apr_global_mutex_child_init (mutex=<optimized out>, fname=<optimized out>, pool=<optimized out>) at locks/unix/global_mutex.c:89

```
With this patch, it shows the following - as well as no more segfaults:

[Fri Feb 25 01:13:58.924341 2022] [:emerg] [pid 92020] (20009)No lock was provided and one was required.: [host test.test] mod_lsapi:  apr_global_mutex_child_init error for pipe mutex