### PR TITLE
dso: Check for NULL handle in apr_dso_sym

### DIFF
--- a/dso/unix/dso.c
+++ b/dso/unix/dso.c
@@ -173,6 +173,18 @@ APR_DECLARE(apr_status_t) apr_dso_sym(apr_dso_handle_sym_t *ressym,
                                       apr_dso_handle_t *handle,
                                       const char *symname)
 {
+    /* This is necessary for `testdso.c`. For some reason, musl
+     * builds fail the `test_unload_library` test if the below
+     * check isn't in place. `test_unload_library` unloads the
+     * library and then immediately calls this function. Maybe
+     * musl's `dlsym()` assumes the handle is never NULL and
+     * some UB is being invoked here...
+     */
+    if (handle->handle == NULL) {
+        handle->errormsg = "library not loaded";
+        return APR_ESYMNOTFOUND;
+    }
+
 #if defined(DSO_USE_SHL)
     void *symaddr = NULL;
     int status;


### PR DESCRIPTION
The voidlinux package for **apr** on musl fails the `test_unload_library` test in `testdso.c` without this `NULL` check. The test unloads the dso and then immediately tries to read a symbol from the unloaded dso, and assumes this fails. I found it was actually succeeding to read the symbol. Maybe musl's `dlsym()` function assumes you won't pass it a `NULL` handle, and this test is invoking some UB.
