### PR TITLE
Change the minimum OS version from XP to Vista.

### DIFF
--- a/include/apr.hw
+++ b/include/apr.hw
@@ -84,9 +84,9 @@
 #endif
 #ifndef _WIN32_WINNT
 
-/* Restrict the server to a subset of Windows XP header files by default
+/* Restrict the server to a subset of Windows Vista header files by default
  */
-#define _WIN32_WINNT 0x0501
+#define _WIN32_WINNT 0x0600
 #endif
 #ifndef NOUSER
 #define NOUSER


### PR DESCRIPTION
As these topics:
[Apache 2.2 build with new VC++ 2008 RTM](https://www.apachelounge.com/viewtopic.php?t=2095)
[apr 1.7.0 build issues](https://www.apachelounge.com/viewtopic.php?t=8260)
From version 1.6.5 and earlier, this value does not affect compilation, but it will break compilation starting with version 1.7.0. I also tried compiling on Visual Studio 2013 and confirmed that the value `0x0501` would break the compilation, but after changing to `0x0600`, the compilation went normally.