### PR TITLE
Don't call my_init() for MySQL 8.0

### DIFF
--- a/dbd/apr_dbd_mysql.c
+++ b/dbd/apr_dbd_mysql.c
@@ -1292,7 +1292,7 @@ static apr_status_t thread_end(void *data)
 
 static void dbd_mysql_init(apr_pool_t *pool)
 {
-#if MYSQL_VERSION_ID < 100000
+#if MYSQL_VERSION_ID < 80000
     my_init();
 #endif
     mysql_thread_init();


### PR DESCRIPTION
From MySQL 8.0.2 changelog:
The my_init() function is no longer included in the list of symbols exported from libmysqlclient. It need not be called explicitly by client programs because it is called implicitly by other C API initialization functions.

Fix for loading the module when compiled with MySQL 8.0 (error: Can't load driver file apr_dbd_mysql.so)

Should still working fine with older MariaDB versions (5.x).