### PR TITLE
Fix socket creation when APR_UNSPEC is used

### DIFF
--- a/memcache/apr_memcache.c
+++ b/memcache/apr_memcache.c
@@ -346,20 +346,9 @@ APR_DECLARE(apr_status_t) apr_memcache_disable_server(apr_memcache_t *mc, apr_me
     return make_server_dead(mc, ms);
 }
 
-static apr_status_t conn_connect(apr_memcache_conn_t *conn)
+static apr_status_t conn_connect(apr_memcache_conn_t *conn, apr_sockaddr_t *sa)
 {
     apr_status_t rv = APR_SUCCESS;
-    apr_sockaddr_t *sa;
-#if APR_HAVE_SOCKADDR_UN
-    apr_int32_t family = conn->ms->host[0] != '/' ? APR_UNSPEC : APR_UNIX;
-#else
-    apr_int32_t family = APR_UNSPEC;
-#endif
-
-    rv = apr_sockaddr_info_get(&sa, conn->ms->host, family, conn->ms->port, 0, conn->p);
-    if (rv != APR_SUCCESS) {
-        return rv;
-    }
 
     rv = apr_socket_timeout_set(conn->sock, 1 * APR_USEC_PER_SEC);
     if (rv != APR_SUCCESS) {
@@ -388,6 +377,7 @@ mc_conn_construct(void **conn_, void *params, apr_pool_t *pool)
     apr_pool_t *np;
     apr_pool_t *tp;
     apr_memcache_server_t *ms = params;
+    apr_sockaddr_t *sa;
 #if APR_HAVE_SOCKADDR_UN
     apr_int32_t family = ms->host[0] != '/' ? APR_UNSPEC : APR_UNIX;
 #else
@@ -410,6 +400,14 @@ mc_conn_construct(void **conn_, void *params, apr_pool_t *pool)
     conn->p = np;
     conn->tp = tp;
 
+    if (family == APR_UNSPEC){
+        rv = apr_sockaddr_info_get(&sa, ms->host, family, ms->port, 0, np);
+        if (rv != APR_SUCCESS) {
+            return rv;
+        }
+        family = sa->family;
+    }
+
     rv = apr_socket_create(&conn->sock, family, SOCK_STREAM, 0, np);
 
     if (rv != APR_SUCCESS) {
@@ -421,7 +419,7 @@ mc_conn_construct(void **conn_, void *params, apr_pool_t *pool)
     conn->blen = 0;
     conn->ms = ms;
 
-    rv = conn_connect(conn);
+    rv = conn_connect(conn, sa);
     if (rv != APR_SUCCESS) {
         apr_pool_destroy(np);
     }

--- a/memcache/apr_memcache.c
+++ b/memcache/apr_memcache.c
@@ -346,18 +346,37 @@ APR_DECLARE(apr_status_t) apr_memcache_disable_server(apr_memcache_t *mc, apr_me
     return make_server_dead(mc, ms);
 }
 
-static apr_status_t conn_connect(apr_memcache_conn_t *conn, apr_sockaddr_t *sa)
+static apr_status_t conn_connect(apr_memcache_conn_t *conn)
 {
     apr_status_t rv = APR_SUCCESS;
+    apr_sockaddr_t *sa;
+#if APR_HAVE_SOCKADDR_UN
+    apr_int32_t family = conn->ms->host[0] != '/' ? APR_UNSPEC : APR_UNIX;
+#else
+    apr_int32_t family = APR_UNSPEC;
+#endif
 
-    rv = apr_socket_timeout_set(conn->sock, 1 * APR_USEC_PER_SEC);
+    rv = apr_sockaddr_info_get(&sa, conn->ms->host, family, conn->ms->port, 0, conn->p);
     if (rv != APR_SUCCESS) {
         return rv;
     }
 
-    rv = apr_socket_connect(conn->sock, sa);
-    if (rv != APR_SUCCESS) {
-        return rv;
+    /* Cycle through address until a connect() succeeds. */
+    for (; sa; sa = sa->next) {
+        rv = apr_socket_create(&conn->sock, sa->family, SOCK_STREAM, 0, conn->p);
+        if (rv == APR_SUCCESS) {
+            rv = apr_socket_timeout_set(conn->sock, 1 * APR_USEC_PER_SEC);
+            if (rv != APR_SUCCESS) {
+                return rv;
+            }
+
+            rv = apr_socket_connect(conn->sock, sa);
+            if (rv == APR_SUCCESS) {
+                break;
+            }
+
+            apr_socket_close(conn->sock);
+        }
     }
 
     rv = apr_socket_timeout_set(conn->sock, -1);
@@ -377,12 +396,6 @@ mc_conn_construct(void **conn_, void *params, apr_pool_t *pool)
     apr_pool_t *np;
     apr_pool_t *tp;
     apr_memcache_server_t *ms = params;
-    apr_sockaddr_t *sa;
-#if APR_HAVE_SOCKADDR_UN
-    apr_int32_t family = ms->host[0] != '/' ? APR_UNSPEC : APR_UNIX;
-#else
-    apr_int32_t family = APR_UNSPEC;
-#endif
 
     rv = apr_pool_create(&np, pool);
     if (rv != APR_SUCCESS) {
@@ -400,26 +413,11 @@ mc_conn_construct(void **conn_, void *params, apr_pool_t *pool)
     conn->p = np;
     conn->tp = tp;
 
-    if (family == APR_UNSPEC){
-        rv = apr_sockaddr_info_get(&sa, ms->host, family, ms->port, 0, np);
-        if (rv != APR_SUCCESS) {
-            return rv;
-        }
-        family = sa->family;
-    }
-
-    rv = apr_socket_create(&conn->sock, family, SOCK_STREAM, 0, np);
-
-    if (rv != APR_SUCCESS) {
-        apr_pool_destroy(np);
-        return rv;
-    }
-
     conn->buffer = apr_palloc(conn->p, BUFFER_SIZE + 1);
     conn->blen = 0;
     conn->ms = ms;
 
-    rv = conn_connect(conn, sa);
+    rv = conn_connect(conn);
     if (rv != APR_SUCCESS) {
         apr_pool_destroy(np);
     }

--- a/memcache/apr_memcache.c
+++ b/memcache/apr_memcache.c
@@ -379,6 +379,10 @@ static apr_status_t conn_connect(apr_memcache_conn_t *conn)
         }
     }
 
+    if (!sa){
+        return APR_ECONNREFUSED;
+    }
+
     rv = apr_socket_timeout_set(conn->sock, -1);
     if (rv != APR_SUCCESS) {
         return rv;


### PR DESCRIPTION
When APR_UNSPEC is used, socket family is automaticaly set to APR_INET6 in apr_socket_create() and therefore if apr_sockaddr_info_get() finds out that the given address is in IPv4 format, it fails when calling apr_socket_connect(). So we first call apr_sockaddr_info_get() to get info about addr family and then pass it to apr_socket_create().