### PR TITLE
MYSQL_OPT_RECONNECT is deprecated in MySQL 8.0.34.

### DIFF
--- a/dbd/apr_dbd_mysql.c
+++ b/dbd/apr_dbd_mysql.c
@@ -1210,7 +1210,7 @@ static apr_dbd_t *dbd_mysql_open(apr_pool_t *pool, const char *params,
     }
 #endif
 
-#if MYSQL_VERSION_ID >= 50013
+#if MYSQL_VERSION_ID >= 50013 && MYSQL_VERSION_ID < 80034
     /* the MySQL manual says this should be BEFORE mysql_real_connect */
     mysql_options(sql->conn, MYSQL_OPT_RECONNECT, &do_reconnect);
 #endif
@@ -1228,7 +1228,7 @@ static apr_dbd_t *dbd_mysql_open(apr_pool_t *pool, const char *params,
         return NULL;
     }
 
-#if MYSQL_VERSION_ID >= 50013
+#if MYSQL_VERSION_ID >= 50013 && MYSQL_VERSION_ID < 80034
     /* Some say this should be AFTER mysql_real_connect */
     mysql_options(sql->conn, MYSQL_OPT_RECONNECT, &do_reconnect);
 #endif


### PR DESCRIPTION
The MySQL client library currently supports performing an automatic reconnection to the server if it finds that the connection is down and an application attempts to send a statement to the server to be executed. Now, this feature is deprecated and subject to removal in a future release of MySQL.

The related MYSQL_OPT_RECONNECT option is still available but it is also deprecated. C API functions [mysql_get_option()](https://dev.mysql.com/doc/c-api/8.1/en/mysql-get-option.html) and [mysql_options()](https://dev.mysql.com/doc/c-api/8.1/en/mysql-options.html) now write a deprecation warning to the standard error output when an application specifies MYSQL_OPT_RECONNECT. (WL #15766)

https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-34.html#mysqld-8-0-34-deprecation-removal
https://dev.mysql.com/doc/relnotes/mysql/8.1/en/news-8-1-0.html#mysqld-8-1-0-deprecation-removal

Similar to issue in DBD-mysql: https://github.com/perl5-dbi/DBD-mysql/issues/354