### PR TITLE
configure: Add bcrypt library for Windows target

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -926,7 +926,7 @@ dnl without the extra " " in that case, but they didn't do that.  So, we
 dnl end up LIBS="-lm -lcrypt -lnsl  -ldl" which is an annoyance.
 case $host in
    *-mingw*)
-      APR_ADDTO(LIBS,[-lshell32 -ladvapi32 -lws2_32 -lrpcrt4 -lmswsock])
+      APR_ADDTO(LIBS,[-lbcrypt -lshell32 -ladvapi32 -lws2_32 -lrpcrt4 -lmswsock])
       ac_cv_func_CreateFileMapping=yes
       ;;
    *)


### PR DESCRIPTION

    bcrypt library is required for BCryptGenRandom function which is used
    in misc/win32/rand.c file. This commit fixes the following linker error

    misc/win32/rand.c:32:(.text+0x13): undefined reference to `BCryptGenRandom'

