### PR TITLE
Fix test failure on i686 due to too big map size

### DIFF
--- a/dbm/apr_dbm_lmdb.c
+++ b/dbm/apr_dbm_lmdb.c
@@ -121,7 +121,7 @@ static apr_status_t vt_lmdb_open(apr_dbm_t **pdb, const char *pathname,
         if (dberr == 0) {
             /*   Default to 2GB map size which limits the total database
              *   size to something reasonable. */
-            dberr = mdb_env_set_mapsize(file.env, UINT32_MAX);
+            dberr = mdb_env_set_mapsize(file.env, INT32_MAX);
         }
 
         if (dberr == 0) {


### PR DESCRIPTION
On i686 vt_lmdb_open() was failing, because UINT32_MAX (4GB) was incorrectly used as database size instead of INT32_MAX (2GB).