### PR TITLE
dbd & dso: ensure functions are declared correctly according to C spec

### DIFF
--- a/dbd/apr_dbd.c
+++ b/dbd/apr_dbd.c
@@ -47,11 +47,11 @@ static apr_uint32_t initialised = 0, in_init = 1;
  * no longer be exported.
  */
 static apr_thread_mutex_t* mutex = NULL;
-APR_DECLARE(apr_status_t) apr_dbd_mutex_lock()
+APR_DECLARE(apr_status_t) apr_dbd_mutex_lock(void)
 {
     return apr_thread_mutex_lock(mutex);
 }
-APR_DECLARE(apr_status_t) apr_dbd_mutex_unlock()
+APR_DECLARE(apr_status_t) apr_dbd_mutex_unlock(void)
 {
     return apr_thread_mutex_unlock(mutex);
 }

--- a/util-misc/apu_dso.c
+++ b/util-misc/apu_dso.c
@@ -40,19 +40,19 @@ static apr_hash_t *dsos = NULL;
 static apr_uint32_t in_init = 0, initialised = 0;
 
 #if APR_HAS_THREADS
-apr_status_t apu_dso_mutex_lock()
+apr_status_t apu_dso_mutex_lock(void)
 {
     return apr_thread_mutex_lock(mutex);
 }
-apr_status_t apu_dso_mutex_unlock()
+apr_status_t apu_dso_mutex_unlock(void)
 {
     return apr_thread_mutex_unlock(mutex);
 }
 #else
-apr_status_t apu_dso_mutex_lock() {
+apr_status_t apu_dso_mutex_lock(void) {
     return APR_SUCCESS;
 }
-apr_status_t apu_dso_mutex_unlock() {
+apr_status_t apu_dso_mutex_unlock(void) {
     return APR_SUCCESS;
 }
 #endif
@@ -232,4 +232,3 @@ apr_status_t apu_dso_load(apr_dso_handle_t **dlhandleptr,
 }
 
 #endif /* APR_DSO_BUILD */
-


### PR DESCRIPTION
apr_dbd_mutex_lock/unlock() and apr_status_t apu_dso_mutex_lock/unlock() functions were declared without a (void). This causes warnings like:

> dbd/apr_dbd.c:50:45: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]

Fix this.

PR: https://bz.apache.org/bugzilla/show_bug.cgi?id=68292