### PR TITLE
apr_brigade_split_line fix for LF handling

### DIFF
--- a/buckets/apr_brigade.c
+++ b/buckets/apr_brigade.c
@@ -359,7 +359,10 @@ APR_DECLARE(apr_status_t) apr_brigade_split_line(apr_bucket_brigade *bbOut,
             pos = memchr(str, APR_ASCII_LF, len);
             /* We found a match. */
             if (pos != NULL) {
-                apr_bucket_split(e, pos - str + 1);
+                /* Split if the LF is not the last character in the bucket. */
+                if ((pos - str + 1) < len) {
+                    apr_bucket_split(e, pos - str + 1);
+                }
                 APR_BUCKET_REMOVE(e);
                 APR_BRIGADE_INSERT_TAIL(bbOut, e);
                 return APR_SUCCESS;


### PR DESCRIPTION
```
* buckets/apr_brigade.c (apr_brigade_split_line): After finding an LF,
  only split the bucket if the LF is not the last character in the
  data.

* test/testbuckets.c (test_splitline_exactly): New test.

PR: 68278
Submitted by: Barnim Dzwillo <dzwillo strato.de>, jorton
```