### PR TITLE
Add option to disable timed dependant tests

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -3121,6 +3121,14 @@ AC_MSG_RESULT($ipv6_result)
 
 AC_SUBST(have_ipv6)
 
+AC_ARG_ENABLE(timed-tests,
+  [  --disable-timed-tests	  Disable timed tests ],
+  [apr_has_timed_tests=$enableval], [apr_has_timed_tests=yes]
+)
+AS_IF([test "x$apr_has_timed_tests" != xno],
+  [AC_DEFINE([APR_HAVE_TIME_DEPENDANT_TESTS], [1], [Whether timed tests should be enabled.])]
+)
+
 # hstrerror is only needed if IPv6 is not enabled,
 # so getaddrinfo/gai_strerror are not used.
 if test $have_ipv6 = 0; then

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -74,7 +74,7 @@ CLEAN_TARGETS = testfile.tmp lfstests/*.bin \
 CLEAN_SUBDIRS = internal
 
 INCDIR=../include
-INCLUDES=-I$(INCDIR) -I$(srcdir)/../include
+INCLUDES=-I$(INCDIR) -I$(srcdir)/../include -I$(srcdir)/../include/arch/@DEFAULT_OSDIR@
 
 # link programs using -no-install to get real executables not
 # libtool wrapper scripts which link an executable when first run.

--- a/test/testlock.c
+++ b/test/testlock.c
@@ -23,6 +23,7 @@
 #include "apr_general.h"
 #include "apr_getopt.h"
 #include "apr_atomic.h"
+#include "apr_private.h"
 #include "testutil.h"
 
 #if APR_HAS_THREADS
@@ -551,13 +552,17 @@ abts_suite *testlock(abts_suite *suite)
     abts_run_test(suite, threads_not_impl, NULL);
 #else
     abts_run_test(suite, test_thread_mutex, NULL);
+#if APR_HAVE_TIME_DEPENDANT_TESTS
     abts_run_test(suite, test_thread_timedmutex, NULL);
+#endif
     abts_run_test(suite, test_thread_nestedmutex, NULL);
     abts_run_test(suite, test_thread_unnestedmutex, NULL);
     abts_run_test(suite, test_thread_rwlock, NULL);
     abts_run_test(suite, test_cond, NULL);
     abts_run_test(suite, test_timeoutcond, NULL);
+#if APR_HAVE_TIME_DEPENDANT_TESTS
     abts_run_test(suite, test_timeoutmutex, NULL);
+#endif
 #ifdef WIN32
     abts_run_test(suite, test_win32_abandoned_mutex, NULL);
 #endif


### PR DESCRIPTION
The disabled tests rely on timing to pass correctly. On a virtualized system under heavy load, these tests randomly fail because they miss a timer or other timing related issues.