### PR TITLE
Add support for pipe2() on Linux.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1210,6 +1210,22 @@ if test "$apr_cv_dup3" = "yes"; then
    AC_DEFINE([HAVE_DUP3], 1, [Define if dup3 function is supported])
 fi
 
+# test for pipe2
+AC_CACHE_CHECK([for pipe2 support], [apr_cv_pipe2],
+[AC_TRY_RUN([
+#include <fcntl.h>
+#include <unistd.h>
+
+int main(int argc, const char **argv)
+{
+    int fds[2];
+    return pipe2(fds, O_NONBLOCK) == -1;
+}], [apr_cv_pipe2=yes], [apr_cv_pipe2=no], [apr_cv_pipe2=no])])
+
+if test "$apr_cv_pipe2" = "yes"; then
+   AC_DEFINE([HAVE_PIPE2], 1, [Define if pipe2 function is supported])
+fi
+
 # Test for accept4().  Create a non-blocking socket, bind it to
 # an unspecified port & address (kernel picks), and attempt to
 # call accept4() on it.  If the syscall is wired up (i.e. the


### PR DESCRIPTION
```
* configure.in: Test for working pipe2().

* file_io/unix/pipe.c (file_pipe_create): Use pipe2(,O_NONBLOCK) if APR_FULL_NONBLOCK is requested.

* test/testpipe.c (nonblock_pipe): New test.
```