### PR TITLE
For thread-debug builds, use error-checking mutexes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,6 +25,8 @@ jobs:
             config: --enable-pool-debug
           - name: Pool-debug, maintainer-mode
             config: --enable-pool-debug --enable-maintainer-mode
+          - name: Thread-debug, maintainer-mode
+            config: --enable-thread-debug --enable-maintainer-mode
           - name: Maintainer-mode, no IPv6
             config: --enable-maintainer-mode --disable-ipv6
           - name: Maintainer-mode, -Werror

--- a/locks/unix/proc_mutex.c
+++ b/locks/unix/proc_mutex.c
@@ -646,6 +646,18 @@ static apr_status_t proc_mutex_pthread_create(apr_proc_mutex_t *new_mutex,
     }
 #endif /* HAVE_PTHREAD_MUTEX_ROBUST[_NP] */
 
+#if defined(APR_THREAD_DEBUG)
+    /* ignore errors. */
+    if ((rv = pthread_mutexattr_settype(&mattr, PTHREAD_MUTEX_ERRORCHECK))) {
+#ifdef HAVE_ZOS_PTHREADS
+        rv = errno;
+#endif
+        proc_mutex_pthread_cleanup(new_mutex);
+        pthread_mutexattr_destroy(&mattr);
+        return rv;
+    }
+#endif
+
     if ((rv = pthread_mutex_init(&proc_pthread_mutex(new_mutex), &mattr))) {
 #ifdef HAVE_ZOS_PTHREADS
         rv = errno;


### PR DESCRIPTION
```
For thread-debug builds, use error-checking mutexes for proc_mutex_pthread:

* locks/unix/proc_mutex.c (proc_mutex_pthread_create):
  [APR_THREAD_PROC]: Set the mutex type to ERRORCHECK.

* test/testprocmutex.c (test_exclusive): Skip the trylock/timedlock tests for thread-debug builds since it triggers undefined behaviour with proc_pthread mutexes.
```