### PR TITLE
Implement apr_shm_perms_set for POSIX shm_open/"classic mmap" shmem

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,10 +17,18 @@ jobs:
       matrix:
         include: 
           - name: Default
+            # Check default shm decision logic for Linux:
+            config-output: APR_USE_SHMEM_MMAP_SHM APR_USE_SHMEM_MMAP_ANON
           - name: Static
             config: --enable-static
           - name: Maintainer-mode
             config: --enable-maintainer-mode
+          - name: Named SHM - SysV, Maintainer-mode
+            config: --enable-maintainer-mode --enable-sysv-shm
+            config-output: APR_USE_SHMEM_SHMGET
+          - name: Named SHM - Classic mmap, Maintainer-mode
+            config: --enable-maintainer-mode ac_cv_func_shm_open=no ac_cv_func_shmget=no
+            config-output: APR_USE_SHMEM_MMAP_TMP
           - name: Pool-debug
             config: --enable-pool-debug
           - name: Pool-debug, maintainer-mode

--- a/shmem/unix/shm.c
+++ b/shmem/unix/shm.c
@@ -732,7 +732,7 @@ APR_PERMS_SET_IMPLEMENT(shm)
         close(fd);
         return rv;
     }
-
+    close(fd);
     return APR_SUCCESS;
 #elif APR_USE_SHMEM_MMAP_TMP
     apr_shm_t *shm = (apr_shm_t *)theshm;

--- a/shmem/unix/shm.c
+++ b/shmem/unix/shm.c
@@ -706,6 +706,40 @@ APR_PERMS_SET_IMPLEMENT(shm)
         return errno;
     }
     return APR_SUCCESS;
+#elif APR_USE_SHMEM_MMAP_SHM
+    apr_shm_t *shm = (apr_shm_t *)theshm;
+    const char *shm_name;
+    int fd;
+
+    if (!shm->filename)
+        return APR_ENOTIMPL;
+
+    shm_name = make_shm_open_safe_name(shm->filename, shm->pool);
+
+    fd = shm_open(shm_name, O_RDWR, 0);
+    if (fd == -1)
+        return errno;
+
+    if (fchown(fd, uid, gid))
+        return errno;
+
+    if (fchmod(fd, apr_unix_perms2mode(perms)))
+        return errno;
+
+    return APR_SUCCESS;
+#elif APR_USE_SHMEM_MMAP_TMP
+    apr_shm_t *shm = (apr_shm_t *)theshm;
+
+    if (!shm->filename)
+        return APR_ENOTIMPL;
+
+    if (chown(shm->filename, uid, gid))
+        return errno;
+
+    if (chmod(shm->filename, apr_unix_perms2mode(perms)))
+        return errno;
+
+    return APR_SUCCESS;
 #else
     return APR_ENOTIMPL;
 #endif

--- a/shmem/unix/shm.c
+++ b/shmem/unix/shm.c
@@ -710,6 +710,7 @@ APR_PERMS_SET_IMPLEMENT(shm)
     apr_shm_t *shm = (apr_shm_t *)theshm;
     const char *shm_name;
     int fd;
+    apr_status_t rv;
 
     if (!shm->filename)
         return APR_ENOTIMPL;
@@ -720,11 +721,17 @@ APR_PERMS_SET_IMPLEMENT(shm)
     if (fd == -1)
         return errno;
 
-    if (fchown(fd, uid, gid))
-        return errno;
+    if (fchown(fd, uid, gid)) {
+        rv = errno;
+        close(fd);
+        return rv;
+    }
 
-    if (fchmod(fd, apr_unix_perms2mode(perms)))
-        return errno;
+    if (fchmod(fd, apr_unix_perms2mode(perms))) {
+        rv = errno;
+        close(fd);
+        return rv;
+    }
 
     return APR_SUCCESS;
 #elif APR_USE_SHMEM_MMAP_TMP


### PR DESCRIPTION
```
* shmem/unix/shm.c (APR_PERMS_SET_IMPLEMENT): Implement for the
  POSIX shm case.

* test/testshm.c (test_named_perms): Add test case.

CI: Add job using --enable-sysv-shm.
```