### PR TITLE
socket option SO_LINGER fix for macOS.

### DIFF
--- a/include/arch/unix/apr_arch_networkio.h
+++ b/include/arch/unix/apr_arch_networkio.h
@@ -93,6 +93,13 @@
 #define POLLNVAL 32
 #endif
 
+#ifdef SO_LINGER
+/* SO_LINGER on macOS works in term of clock ticks */
+#ifndef SO_LINGER_SEC
+#define SO_LINGER_SEC SO_LINGER
+#endif
+#endif
+
 typedef struct sock_userdata_t sock_userdata_t;
 struct sock_userdata_t {
     sock_userdata_t *next;

--- a/network_io/unix/sockopt.c
+++ b/network_io/unix/sockopt.c
@@ -193,12 +193,12 @@ apr_status_t apr_socket_opt_set(apr_socket_t *sock,
         }
         break;
     case APR_SO_LINGER:
-#ifdef SO_LINGER
+#ifdef SO_LINGER_SEC
         if (apr_is_option_set(sock, APR_SO_LINGER) != on) {
             struct linger li;
             li.l_onoff = on;
             li.l_linger = APR_MAX_SECS_TO_LINGER;
-            if (setsockopt(sock->socketdes, SOL_SOCKET, SO_LINGER, (char *) &li, sizeof(struct linger)) == -1) {
+            if (setsockopt(sock->socketdes, SOL_SOCKET, SO_LINGER_SEC, (char *) &li, sizeof(struct linger)) == -1) {
                 return errno;
             }
             apr_set_option(sock, APR_SO_LINGER, on);


### PR DESCRIPTION
SO_LINGER, on this platform, works differently than other unixes in that it does in term of clock ticks rather than seconds. Thus, the existence of the SO_LINGER_SEC option, we define it to every other platforms for simplicity sake.