### PR TITLE
Check for potential null pointer

### DIFF
--- a/buckets/apr_brigade.c
+++ b/buckets/apr_brigade.c
@@ -88,6 +88,9 @@ APR_DECLARE(apr_bucket_brigade *) apr_brigade_create(apr_pool_t *p,
     apr_bucket_brigade *b;
 
     b = apr_palloc(p, sizeof(*b));
+    if (b == NULL) {
+        return NULL;
+    }
     b->p = p;
     b->bucket_alloc = list;
 
@@ -321,6 +324,9 @@ APR_DECLARE(apr_status_t) apr_brigade_pflatten(apr_bucket_brigade *bb,
     total = (apr_size_t)actual;
 
     *c = apr_palloc(pool, total);
+    if (*c == NULL) {
+        return APR_ENOMEM;
+    }
 
     rv = apr_brigade_flatten(bb, *c, &total);
 

--- a/buffer/apr_buffer.c
+++ b/buffer/apr_buffer.c
@@ -378,6 +378,10 @@ APR_DECLARE(char *) apr_buffer_pstrncat(apr_pool_t *p, const apr_buffer_t *buf,
 
     str = dst = apr_palloc(p, size + 1);
 
+    if (!str) {
+        return NULL;
+    }
+
     src = buf;
 
     for (i = 0; i < nelts; i++) {

--- a/crypto/apr_crypto.c
+++ b/crypto/apr_crypto.c
@@ -132,6 +132,10 @@ APR_DECLARE(apr_status_t) apr_crypto_clear(apr_pool_t *pool,
 {
     apr_crypto_clear_t *clear = apr_palloc(pool, sizeof(apr_crypto_clear_t));
 
+    if (!clear) {
+        return APR_ENOMEM;
+    }
+
     clear->buffer = buffer;
     clear->size = size;
 

--- a/dbd/apr_dbd_mysql.c
+++ b/dbd/apr_dbd_mysql.c
@@ -163,6 +163,9 @@ static apr_status_t lob_bucket_read(apr_bucket *e, const char **str,
 
     /* allocate new buffer, since we used this one for the bucket */
     bind->buffer = apr_palloc(res->pool, bind->buffer_length);
+    if (bind->buffer == NULL) {
+        return APR_ENOMEM;
+    }
 
     /*
      * Change the current bucket to refer to what we read,
@@ -242,6 +245,9 @@ static int dbd_mysql_select(apr_pool_t *pool, apr_dbd_t *sql,
             if (!*results) {
                 *results = apr_palloc(pool, sizeof(apr_dbd_results_t));
             }
+            if (!*results) {
+                return CR_OUT_OF_MEMORY;
+            }
             (*results)->random = seek;
             (*results)->statement = NULL;
             (*results)->pool = pool;
@@ -318,6 +324,9 @@ static int dbd_mysql_get_row(apr_pool_t *pool, apr_dbd_results_t *res,
     if (ret == 0) {
         if (!*row) {
             *row = apr_palloc(pool, sizeof(apr_dbd_row_t));
+            if (!*row) {
+                return CR_OUT_OF_MEMORY;
+            }
         }
         (*row)->row = r;
         (*row)->res = res;
@@ -592,6 +601,9 @@ static int dbd_mysql_prepare(apr_pool_t *pool, apr_dbd_t *sql,
 
     if (!*statement) {
         *statement = apr_palloc(pool, sizeof(apr_dbd_prepared_t));
+        if (!*statement) {
+            return CR_OUT_OF_MEMORY;
+        }
     }
     (*statement)->stmt = mysql_stmt_init(sql->conn);
 

--- a/encoding/apr_escape.c
+++ b/encoding/apr_escape.c
@@ -104,7 +104,9 @@ APR_DECLARE(const char *) apr_pescape_shell(apr_pool_t *p, const char *str)
     switch (apr_escape_shell(NULL, str, APR_ESCAPE_STRING, &len)) {
     case APR_SUCCESS: {
         char *cmd = apr_palloc(p, len);
-        apr_escape_shell(cmd, str, APR_ESCAPE_STRING, NULL);
+        if (cmd) {
+            apr_escape_shell(cmd, str, APR_ESCAPE_STRING, NULL);
+        }
         return cmd;
     }
     case APR_NOTFOUND: {
@@ -258,8 +260,10 @@ APR_DECLARE(const char *) apr_punescape_url(apr_pool_t *p, const char *url,
             plus, &len)) {
     case APR_SUCCESS: {
         char *buf = apr_palloc(p, len);
-        apr_unescape_url(buf, url, APR_ESCAPE_STRING, forbid, reserved, plus,
-                NULL);
+        if (buf){
+            apr_unescape_url(buf, url, APR_ESCAPE_STRING, forbid, reserved, plus,
+                    NULL);
+        }
         return buf;
     }
     case APR_EINVAL:
@@ -355,7 +359,9 @@ APR_DECLARE(const char *) apr_pescape_path_segment(apr_pool_t *p,
     switch (apr_escape_path_segment(NULL, str, APR_ESCAPE_STRING, &len)) {
     case APR_SUCCESS: {
         char *cmd = apr_palloc(p, len);
-        apr_escape_path_segment(cmd, str, APR_ESCAPE_STRING, NULL);
+        if (cmd) {
+            apr_escape_path_segment(cmd, str, APR_ESCAPE_STRING, NULL);
+        }
         return cmd;
     }
     case APR_NOTFOUND: {
@@ -438,7 +444,9 @@ APR_DECLARE(const char *) apr_pescape_path(apr_pool_t *p, const char *str,
     switch (apr_escape_path(NULL, str, APR_ESCAPE_STRING, partial, &len)) {
     case APR_SUCCESS: {
         char *path = apr_palloc(p, len);
-        apr_escape_path(path, str, APR_ESCAPE_STRING, partial, NULL);
+        if (path) {
+            apr_escape_path(path, str, APR_ESCAPE_STRING, partial, NULL);
+        }
         return path;
     }
     case APR_NOTFOUND: {
@@ -512,7 +520,9 @@ APR_DECLARE(const char *) apr_pescape_urlencoded(apr_pool_t *p, const char *str)
     switch (apr_escape_urlencoded(NULL, str, APR_ESCAPE_STRING, &len)) {
     case APR_SUCCESS: {
         char *encoded = apr_palloc(p, len);
-        apr_escape_urlencoded(encoded, str, APR_ESCAPE_STRING, NULL);
+        if (encoded) {
+            apr_escape_urlencoded(encoded, str, APR_ESCAPE_STRING, NULL);
+        }
         return encoded;
     }
     case APR_NOTFOUND: {
@@ -643,7 +653,9 @@ APR_DECLARE(const char *) apr_pescape_entity(apr_pool_t *p, const char *str,
     switch (apr_escape_entity(NULL, str, APR_ESCAPE_STRING, toasc, &len)) {
     case APR_SUCCESS: {
         char *cmd = apr_palloc(p, len);
-        apr_escape_entity(cmd, str, APR_ESCAPE_STRING, toasc, NULL);
+        if (cmd) {
+            apr_escape_entity(cmd, str, APR_ESCAPE_STRING, toasc, NULL);
+        }
         return cmd;
     }
     case APR_NOTFOUND: {
@@ -817,7 +829,9 @@ APR_DECLARE(const char *) apr_punescape_entity(apr_pool_t *p, const char *str)
     switch (apr_unescape_entity(NULL, str, APR_ESCAPE_STRING, &len)) {
     case APR_SUCCESS: {
         char *cmd = apr_palloc(p, len);
-        apr_unescape_entity(cmd, str, APR_ESCAPE_STRING, NULL);
+        if (cmd) {
+            apr_unescape_entity(cmd, str, APR_ESCAPE_STRING, NULL);
+        }
         return cmd;
     }
     case APR_NOTFOUND: {
@@ -966,7 +980,9 @@ APR_DECLARE(const char *) apr_pescape_echo(apr_pool_t *p, const char *str,
     switch (apr_escape_echo(NULL, str, APR_ESCAPE_STRING, quote, &len)) {
     case APR_SUCCESS: {
         char *cmd = apr_palloc(p, len);
-        apr_escape_echo(cmd, str, APR_ESCAPE_STRING, quote, NULL);
+        if (cmd) {
+            apr_escape_echo(cmd, str, APR_ESCAPE_STRING, quote, NULL);
+        }
         return cmd;
     }
     case APR_NOTFOUND: {
@@ -1018,7 +1034,9 @@ APR_DECLARE(const char *) apr_pescape_hex(apr_pool_t *p, const void *src,
     switch (apr_escape_hex(NULL, src, srclen, colon, &len)) {
     case APR_SUCCESS: {
         char *cmd = apr_palloc(p, len);
-        apr_escape_hex(cmd, src, srclen, colon, NULL);
+        if (cmd) {
+            apr_escape_hex(cmd, src, srclen, colon, NULL);
+        }
         return cmd;
     }
     case APR_NOTFOUND: {
@@ -1129,7 +1147,9 @@ APR_DECLARE(const void *) apr_punescape_hex(apr_pool_t *p, const char *str,
     switch (apr_unescape_hex(NULL, str, APR_ESCAPE_STRING, colon, &size)) {
     case APR_SUCCESS: {
         void *cmd = apr_palloc(p, size);
-        apr_unescape_hex(cmd, str, APR_ESCAPE_STRING, colon, len);
+        if (cmd) {
+            apr_unescape_hex(cmd, str, APR_ESCAPE_STRING, colon, len);
+        }
         return cmd;
     }
     case APR_BADCH:
@@ -1200,7 +1220,9 @@ APR_DECLARE(const char *) apr_pescape_ldap(apr_pool_t *p, const void *src,
     switch (apr_escape_ldap(NULL, src, srclen, flags, &len)) {
     case APR_SUCCESS: {
         char *encoded = apr_palloc(p, len);
-        apr_escape_ldap(encoded, src, srclen, flags, NULL);
+        if (encoded) {
+            apr_escape_ldap(encoded, src, srclen, flags, NULL);
+        }
         return encoded;
     }
     case APR_NOTFOUND: {
@@ -1469,7 +1491,9 @@ APR_DECLARE(const char *) apr_pescape_json(apr_pool_t *p, const char *src,
     }
     default: {
         char *encoded = apr_palloc(p, len);
-        apr_escape_json(encoded, src, srclen, quote, NULL);
+        if (encoded) {
+            apr_escape_json(encoded, src, srclen, quote, NULL);
+        }
         return encoded;
     }
     }

--- a/file_io/os2/filedup.c
+++ b/file_io/os2/filedup.c
@@ -94,6 +94,10 @@ APR_DECLARE(apr_status_t) apr_file_setaside(apr_file_t **new_file,
         (*new_file)->buffer = apr_palloc(p, old_file->bufsize);
         (*new_file)->bufsize = old_file->bufsize;
 
+        if ((*new_file)->buffer == NULL) {
+            return APR_ENOMEM;
+        }
+
         if (old_file->direction == 1) {
             memcpy((*new_file)->buffer, old_file->buffer, old_file->bufpos);
         }

--- a/file_io/os2/open.c
+++ b/file_io/os2/open.c
@@ -66,7 +66,9 @@ APR_DECLARE(apr_status_t) apr_file_open(apr_file_t **new, const char *fname, apr
     if (dafile->buffered) {
         dafile->buffer = apr_palloc(pool, APR_FILE_DEFAULT_BUFSIZE);
         dafile->bufsize = APR_FILE_DEFAULT_BUFSIZE;
-
+        if (dafile->buffer == NULL) {
+            return APR_ENOMEM;
+        }
         if (flag & APR_FOPEN_XTHREAD) {
             rv = apr_thread_mutex_create(&dafile->mutex, 0, pool);
 
@@ -196,6 +198,9 @@ APR_DECLARE(apr_status_t) apr_os_file_put(apr_file_t **file, apr_os_file_t *thef
     apr_os_file_t *dafile = thefile;
 
     (*file) = apr_palloc(pool, sizeof(apr_file_t));
+    if ((*file) == NULL) {
+        return APR_ENOMEM;
+    }
     (*file)->pool = pool;
     (*file)->filedes = *dafile;
     (*file)->isopen = TRUE;
@@ -210,6 +215,9 @@ APR_DECLARE(apr_status_t) apr_os_file_put(apr_file_t **file, apr_os_file_t *thef
 
         (*file)->buffer = apr_palloc(pool, APR_FILE_DEFAULT_BUFSIZE);
         (*file)->bufsize = APR_FILE_DEFAULT_BUFSIZE;
+        if ((*file)->buffer == NULL) {
+            return APR_ENOMEM;
+        }
         rv = apr_thread_mutex_create(&(*file)->mutex, 0, pool);
 
         if (rv)

--- a/file_io/os2/pipe.c
+++ b/file_io/os2/pipe.c
@@ -56,6 +56,11 @@ static apr_status_t file_pipe_create(apr_file_t **in, apr_file_t **out,
     }
 
     (*in) = (apr_file_t *)apr_palloc(pool_in, sizeof(apr_file_t));
+    if (!(*in)) {
+        DosClose(filedes[0]);
+        DosClose(filedes[1]);
+        return APR_ENOMEM;
+    }
     rc = DosCreateEventSem(NULL, &(*in)->pipeSem, DC_SEM_SHARED, FALSE);
 
     if (rc) {
@@ -91,6 +96,12 @@ static apr_status_t file_pipe_create(apr_file_t **in, apr_file_t **out,
             apr_pool_cleanup_null);
 
     (*out) = (apr_file_t *)apr_palloc(pool_out, sizeof(apr_file_t));
+    if (!(*out)) {
+        DosClose(filedes[0]);
+        DosClose(filedes[1]);
+        DosCloseEventSem((*in)->pipeSem);
+        return APR_ENOMEM;
+    }
     rc = DosCreateEventSem(NULL, &(*out)->pipeSem, DC_SEM_SHARED, FALSE);
 
     if (rc) {

--- a/file_io/unix/dir.c
+++ b/file_io/unix/dir.c
@@ -82,7 +82,9 @@ apr_status_t apr_dir_open(apr_dir_t **new, const char *dirname,
     }
 
     (*new) = (apr_dir_t *)apr_palloc(pool, sizeof(apr_dir_t));
-
+    if (!(*new)) {
+        return APR_ENOMEM;
+    }
     (*new)->pool = pool;
     (*new)->dirname = apr_pstrdup(pool, dirname);
     (*new)->dirstruct = dir;

--- a/file_io/unix/filedup.c
+++ b/file_io/unix/filedup.c
@@ -91,6 +91,9 @@ static apr_status_t file_dup(apr_file_t **new_file,
     if ((*new_file)->buffered && !(*new_file)->buffer) {
         (*new_file)->buffer = apr_palloc(p, old_file->bufsize);
         (*new_file)->bufsize = old_file->bufsize;
+        if ((*new_file)->buffer == NULL) {
+            return APR_ENOMEM;
+        }
     }
 
     /* this is the way dup() works */
@@ -161,6 +164,9 @@ APR_DECLARE(apr_status_t) apr_file_setaside(apr_file_t **new_file,
     if (old_file->buffered) {
         (*new_file)->buffer = apr_palloc(p, old_file->bufsize);
         (*new_file)->bufsize = old_file->bufsize;
+        if ((*new_file)->buffer == NULL) {
+            return APR_ENOMEM;
+        }
         if (old_file->direction == 1) {
             memcpy((*new_file)->buffer, old_file->buffer, old_file->bufpos);
         }

--- a/file_io/unix/filepath.c
+++ b/file_io/unix/filepath.c
@@ -155,6 +155,10 @@ APR_DECLARE(apr_status_t) apr_filepath_merge(char **newpath,
     }
     path = (char *)apr_palloc(p, maxlen);
 
+    if (path == NULL) {
+        return APR_ENOMEM;
+    }
+
     if (addpath[0] == '/') {
         /* Ignore the given root path, strip off leading
          * '/'s to a single leading '/' from the addpath,

--- a/file_io/unix/filepath_util.c
+++ b/file_io/unix/filepath_util.c
@@ -96,6 +96,9 @@ APR_DECLARE(apr_status_t) apr_filepath_list_merge(char **liststr,
 
     /* Merge the path components */
     path = *liststr = apr_palloc(p, path_size + 1);
+    if (path == NULL) {
+        return APR_ENOMEM;
+    }
     for (i = 0; i < pathelts->nelts; ++i)
     {
         /* ### Hmmmm. Calling strlen twice on the same string. Yuck.

--- a/file_io/unix/open.c
+++ b/file_io/unix/open.c
@@ -219,6 +219,9 @@ APR_DECLARE(apr_status_t) apr_file_open(apr_file_t **new,
     if ((*new)->buffered) {
         (*new)->buffer = apr_palloc(pool, APR_FILE_DEFAULT_BUFSIZE);
         (*new)->bufsize = APR_FILE_DEFAULT_BUFSIZE;
+        if ((*new)->buffer == NULL) {
+            return APR_ENOMEM;
+        }
     }
     else {
         (*new)->buffer = NULL;
@@ -334,6 +337,9 @@ APR_DECLARE(apr_status_t) apr_os_file_put(apr_file_t **file,
     if ((*file)->buffered) {
         (*file)->buffer = apr_palloc(pool, APR_FILE_DEFAULT_BUFSIZE);
         (*file)->bufsize = APR_FILE_DEFAULT_BUFSIZE;
+        if ((*file)->buffer == NULL) {
+            return APR_ENOMEM;
+        }
 #if APR_HAS_THREADS
         if ((*file)->flags & APR_FOPEN_XTHREAD) {
             apr_status_t rv;

--- a/file_io/win32/dir.c
+++ b/file_io/win32/dir.c
@@ -56,6 +56,9 @@ APR_DECLARE(apr_status_t) apr_dir_open(apr_dir_t **new, const char *dirname,
      * and double-null terminate so we have one character to change.
      */
     (*new)->dirname = apr_palloc(pool, len + 3);
+    if ((*new)->dirname == NULL) {
+        return APR_ENOMEM;
+    }
     memcpy((*new)->dirname, dirname, len);
     if (len && (*new)->dirname[len - 1] != '/') {
         (*new)->dirname[len++] = '/';

--- a/file_io/win32/filedup.c
+++ b/file_io/win32/filedup.c
@@ -187,6 +187,9 @@ APR_DECLARE(apr_status_t) apr_file_setaside(apr_file_t **new_file,
     if (old_file->buffered) {
         (*new_file)->buffer = apr_palloc(p, old_file->bufsize);
         (*new_file)->bufsize = old_file->bufsize;
+        if ((*new_file)->buffer == NULL) {
+            return APR_ENOMEM;
+        }
         if (old_file->direction == 1) {
             memcpy((*new_file)->buffer, old_file->buffer, old_file->bufpos);
         }

--- a/file_io/win32/filepath.c
+++ b/file_io/win32/filepath.c
@@ -269,6 +269,9 @@ APR_DECLARE(apr_status_t) apr_filepath_root(const char **rootpath,
          */
         *inpath = testpath + 1;
         newpath = apr_palloc(p, 2);
+        if (newpath == NULL) {
+            return APR_ENOMEM;
+        }
         if (flags & APR_FILEPATH_TRUENAME)
             newpath[0] = seperator[0];
         else
@@ -289,6 +292,9 @@ APR_DECLARE(apr_status_t) apr_filepath_root(const char **rootpath,
          * side effects of legal mis-mapped non-us-ascii codes.
          */
         newpath = apr_palloc(p, 4);
+        if (newpath == NULL) {
+            return APR_ENOMEM;
+        }
         newpath[0] = testpath[0];
         newpath[1] = testpath[1];
         newpath[2] = seperator[0];

--- a/file_io/win32/open.c
+++ b/file_io/win32/open.c
@@ -157,6 +157,9 @@ void *res_name_from_filename(const char *file, int global, apr_pool_t *pool)
         }
     }
     wfile = apr_palloc(pool, (r + n) * sizeof(apr_wchar_t));
+    if (!wfile) {
+        return NULL;
+    }
     wcscpy(wfile, wpre);
     d = n;
     if (apr_conv_utf8_to_utf16(file, &n, wfile + r, &d)) {
@@ -375,6 +378,9 @@ APR_DECLARE(apr_status_t) apr_file_open(apr_file_t **new, const char *fname,
         (*new)->buffered = 1;
         (*new)->buffer = apr_palloc(pool, APR_FILE_DEFAULT_BUFSIZE);
         (*new)->bufsize = APR_FILE_DEFAULT_BUFSIZE;
+        if ((*new)->buffer == NULL) {
+            return APR_ENOMEM;
+        }
     }
     /* Need the mutex to share an apr_file_t across multiple threads */
     if (flag & APR_FOPEN_XTHREAD) {
@@ -511,6 +517,9 @@ APR_DECLARE(apr_status_t) apr_os_file_put(apr_file_t **file,
         (*file)->buffered = 1;
         (*file)->buffer = apr_palloc(pool, APR_FILE_DEFAULT_BUFSIZE);
         (*file)->bufsize = APR_FILE_DEFAULT_BUFSIZE;
+        if ((*file)->buffer == NULL) {
+            return APR_ENOMEM;
+        }
     }
     if (flags & APR_FOPEN_XTHREAD) {
         apr_status_t rv;


### PR DESCRIPTION
`apr_palloc` may return NULL pointer. It may trigger undefined behavior in later usage. For example, passing a null pointer to `memcpy` may trigger undefined behavior. Thus it is better to check for NULL.