### PR TITLE
Force USE_SHMEM_SHMGET on OS400

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1476,7 +1476,7 @@ case $host in
                                   USE_SHMEM_SHMGET)
         fi
         ;;
-    *aix* )
+    *aix* | *os400 )
         # AIX cannot lseek() shared memory, and we always truncate/lseek together
         APR_DECISION_OVERRIDE(USE_SHMEM_SHMGET)
        ;;


### PR DESCRIPTION
Force USE_SHMEM_SHMGET on OS400. When default USE_SHMEM_MMAP_SHM is used, the **testshm** test fails with "Illegal instruction"