### PR TITLE
Force libuuid usage for IBM i (os400).

### DIFF
--- a/build/apr_hints.m4
+++ b/build/apr_hints.m4
@@ -433,6 +433,14 @@ dnl	       # Not a problem in 10.20.  Otherwise, who knows?
         APR_SETIFNULL(apr_gethostbyname_is_thread_safe, [yes])
         APR_SETIFNULL(apr_gethostbyaddr_is_thread_safe, [yes])
         APR_SETIFNULL(apr_getservbyname_is_thread_safe, [yes])
+        APR_SETIFNULL(ac_cv_func_uuid_create, [no])
+        APR_SETIFNULL(ac_cv_search_uuid_create, [no])
+        APR_SETIFNULL(ac_cv_header_uuid_h, [no])
+        APR_ADDTO(CFLAGS, [-D_THREAD_SAFE -D_LINUX_SOURCE_COMPAT -pthread -I/qopensys/pkgs/include/libxml2])
+        APR_SETVAR(SHELL, [/qopensys/bin/sh])
+        APR_SETVAR(CONFIG_SHELL, [/qopensys/bin/sh])
+        APR_SETVAR(AR, [ar -X64])
+        APR_SETVAR(NM, [nm -X64 -B])
         ;;
     *mingw*)
         APR_ADDTO(INTERNAL_CPPFLAGS, -DBINPATH=$apr_builddir/test/.libs)
@@ -497,8 +505,8 @@ case "$host" in
   *-ibm-os390)
       APR_SETIFNULL(CC, [cc])
       ;;
-  *-ibm-as400)
-      APR_SETIFNULL(CC, [icc])
+  *-ibm-as400 | *-ibm-os400)
+      APR_SETIFNULL(CC, [gcc-12 -m64])
       ;;
   *-isc4*)
       APR_SETIFNULL(CC, [gcc])

--- a/configure.in
+++ b/configure.in
@@ -1478,7 +1478,7 @@ case $host in
                                   USE_SHMEM_SHMGET)
         fi
         ;;
-    *aix* )
+    *aix* | *os400)
         # AIX cannot lseek() shared memory, and we always truncate/lseek together
         APR_DECISION_OVERRIDE(USE_SHMEM_SHMGET)
        ;;


### PR DESCRIPTION
Force using libuuid on IBM i (OS400). LIBC procedures do not work on this platform (https://github.com/IBM/ibmi-oss-issues/issues/82)