### PR TITLE
Fix teststr segfault when built with `-ftrivial-auto-var-init`

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -87,6 +87,9 @@ jobs:
             notest-cflags: -Werror
             config: --enable-maintainer-mode --with-berkeley-db --with-dbm=db5
             config-output: APU_HAVE_DB
+          - name: Auto-var-init
+            os: ubuntu-latest  # requires gcc 12 or higher
+            notest-cflags: -ftrivial-auto-var-init=zero
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/test/teststr.c
+++ b/test/teststr.c
@@ -48,10 +48,15 @@ static void test_strtok(abts_case *tc, void *data)
             "      asdf jkl; 77889909            \r\n\1\2\3Z",
             " \r\n\3\2\1"
         },
+#if 0
+/* don't do this... apr_strtok() is not supposed to be called with
+ * str == NULL in the first invocation, otherwise it segfaults.
+ */
         {
-            NULL,  /* but who cares if apr_strtok() segfaults? */
+            NULL,
             " \t"
         },
+#endif
 #if 0     /* don't do this... you deserve to segfault */
         {
             "a b c              ",


### PR DESCRIPTION

The apr test suite has a test error (segfault) when built with `-ftrivial-auto-var-init=zero`:

```bash
$ ./testall -v -q
testatomic : SUCCESS
testdir : SUCCESS
...
teststr             :  Segmentation fault
```

Debug stack trace:

```gdb
(gdb) bt
#0 apr_strtok (str=str@entry=0x0, sep=sep@entry=0x43a429 " \t", last=last@entry=0x7fffffffe2d8) at strings/apr_strtok.c:35
#1 test_strtok (tc=0x7fffffffe380, data=<optimized out>) at test/teststr.c:81
```

Root cause analysis:

- https://github.com/apache/apr/blob/e461da5864fdd2fca6a15ec8d6c42d7f67c5f199/test/teststr.c#L52
- https://github.com/apache/apr/blob/e461da5864fdd2fca6a15ec8d6c42d7f67c5f199/test/teststr.c#L81
- The `apr_strtok(str, sep, internal_state)` function must not be called with `str == NULL` in the first invocation. However the test does exactly this, and this leads to an access to `*internal_state`, which is technically undefined (uninitialized pointer on the stack).
- Without `-ftrivial-auto-var-init=zero`, the `*internal_state` is benign by accident: the previous test case left the pointer-on-stack with some reasonable address. However, with `-ftrivial-auto-var-init=zero`, the `*internal_state` access fails because `internal_state = NULL` (auto-initialized to zero). So the whole test segfaults.

### Reproducer

```bash
docker run -it amazonlinux:2023 /bin/bash

dnf install -y git vim make gcc14 autoconf libtool expat-devel
export CC=gcc14-gcc
export CFLAGS="$CFLAGS -ftrivial-auto-var-init=zero"

./buildconf
./configure
make -j
make test  # fails

cd test && ./testall -v -q  # to see the failure more clearly
```

Note that `-ftrivial-auto-var-init=zero` flag was introduced in GCC v12.

### Testing the fix

```bash
$ cd test && ./testall -v -q
...
testsockopt         :  SUCCESS
teststr             :  SUCCESS  # <-- works now!
teststrnatcmp       :  SUCCESS
...
```